### PR TITLE
Fix TypeError on Python 3.5 (xenial)

### DIFF
--- a/lib/charms/layer/vaultlocker.py
+++ b/lib/charms/layer/vaultlocker.py
@@ -170,7 +170,7 @@ def create_encrypted_loop_mount(mount_path, block_size='1M', block_count=20,
         check_call(['dd', 'if=/dev/urandom', 'of={}'.format(backing_file),
                     'bs=1M', 'count=20'])
         # claim an unused loop device
-        check_call(['losetup', '-f', backing_file])
+        check_call(['losetup', '-f', str(backing_file)])
         # find the loop device we claimed
         device_name = _find_loop_device(backing_file)
         # encrypt the new loop device


### PR DESCRIPTION
Prior to Python 3.6, `pathlib.Path` objects need to be converted to strings before being passed to many standard library functions.

See https://docs.python.org/3.6/whatsnew/3.6.html#pep-519-adding-a-file-system-path-protocol

Fixes [lp:1881302](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1881302)