### PR TITLE
Refactor handling of loop device selection

### DIFF
--- a/templates/vaultlocker-loop@.service
+++ b/templates/vaultlocker-loop@.service
@@ -9,4 +9,4 @@ Before=vaultlocker-decrypt@%i.service
 Type=oneshot
 RemainAfterExit=true
 EnvironmentFile=/etc/vaultlocker/loop-envs/%i
-ExecStart=/sbin/losetup ${DEVICE} ${BACK_FILE}
+ExecStart=/sbin/losetup -f ${BACK_FILE}


### PR DESCRIPTION
Refactor the way the loop device for the encrypted mount is selected to fix two issues:

  * Trying to recover the same loop device after reboot can lead to conflicts and is generally unnecessary ([lp:1893936](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1893936))

  * On Xenial, the code parsing the output of the loop device listing will raise a TypeError due to Python version differences ([lp:1893987](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1893987))